### PR TITLE
Remove inline torch_summary install and document dependencies

### DIFF
--- a/Practical Week 02.ipynb
+++ b/Practical Week 02.ipynb
@@ -66,6 +66,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "0f3fab15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torchsummary import summary"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 2,
    "metadata": {
     "execution": {
@@ -250,44 +260,6 @@
    "source": [
     "import week2\n",
     "mnist_model = week2.build_mnist_model(64, 0.4)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-08-13T02:33:18.404612Z",
-     "iopub.status.busy": "2025-08-13T02:33:18.404415Z",
-     "iopub.status.idle": "2025-08-13T02:33:19.358551Z",
-     "shell.execute_reply": "2025-08-13T02:33:19.356384Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: torch_summary in /opt/anaconda3/lib/python3.12/site-packages (1.4.5)\n",
-      "=================================================================\n",
-      "Layer (type:depth-idx)                   Param #\n",
-      "=================================================================\n",
-      "├─Linear: 1-1                            50,240\n",
-      "├─ReLU: 1-2                              --\n",
-      "├─Dropout: 1-3                           --\n",
-      "├─Linear: 1-4                            650\n",
-      "=================================================================\n",
-      "Total params: 50,890\n",
-      "Trainable params: 50,890\n",
-      "Non-trainable params: 0\n",
-      "=================================================================\n"
-     ]
-    }
-   ],
-   "source": [
-    "!pip install torch_summary\n",
-    "from torchsummary import summary\n",
-    "summary(mnist_model);"
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Practical week 2
 Read the instructions in file [Practical Week 02.ipynb](Practical%20Week%2002.ipynb).
 
-To run the code, you may need to install the following software (and additional software, depending on how you solved the tasks
+To run the code, you may need to install the following software (and additional software, depending on how you solved the tasks):
 
 - `opencv_python` (if this package does not work well, try this other one: `opencv_python_headless`)
 - `numpy` (may not be needed if you have installed `opencv_python`)
 - `matplotlib` (may not be needed if you have installed `opencv_python`)
+- `torch`
+- `torchvision`
+- `torch-summary`
 
 The automatic tests are designed only for the functions defined in file `week2.py`. Execute the following file to test the functions:
 


### PR DESCRIPTION
## Summary
- drop in-notebook `pip install torch_summary` cell and keep import only
- list torch, torchvision, and torch-summary as required packages in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c0136d25c83218ee3027e559df02d